### PR TITLE
Make Steem-Bridging-Header.h references file system independent

### DIFF
--- a/Steem.xcodeproj/project.pbxproj
+++ b/Steem.xcodeproj/project.pbxproj
@@ -429,7 +429,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = riensen.steem;
 				PRODUCT_NAME = Steem;
 				SWIFT_INCLUDE_PATHS = "";
-				SWIFT_OBJC_BRIDGING_HEADER = "/Users/inkenkuhlmann/Projects/xcode/steem/steem/Steem-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/steem/Steem-Bridging-Header.h";
 			};
 			name = Debug;
 		};
@@ -447,7 +447,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = riensen.steem;
 				PRODUCT_NAME = Steem;
 				SWIFT_INCLUDE_PATHS = "";
-				SWIFT_OBJC_BRIDGING_HEADER = "/Users/inkenkuhlmann/Projects/xcode/steem/steem/Steem-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/steem/Steem-Bridging-Header.h";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This is a partial fix for my issue #4. It changes the absolute path on inkenkuhlmann's disk to `$(PROJECT_DIR)/...` in the two `SWIFT_OBJC_BRIDGING_HEADER` settings.
